### PR TITLE
Fix recent weaknotes

### DIFF
--- a/_posts/weaknotes/2024-07-14-weaknotes-306.md
+++ b/_posts/weaknotes/2024-07-14-weaknotes-306.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Week 305: Murder cat"
+title: "Week 306: Murder cat"
 date: 2024-07-14
 category: weaknotes
 ---

--- a/_posts/weaknotes/2024-07-21-weaknotes-307.md
+++ b/_posts/weaknotes/2024-07-21-weaknotes-307.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Week 307: Sungold"
-date: 2024-07-27
+date: 2024-07-21
 category: weaknotes
 ---
 * It occurred to me this week that I could put _all_ the annual + mid-year review feedback I've had over 8 years at the FT into chatGPT and do... something?


### PR DESCRIPTION
Weaknotes 307 aren’t publishing (yet) because their date’s in the future. Might as well fix up the title of weaknotes 306 while we’re at it.